### PR TITLE
work around remaining --smart option in Pod::Simple::Pandoc::_pod_data()

### DIFF
--- a/lib/Pod/Simple/Pandoc.pm
+++ b/lib/Pod/Simple/Pandoc.pm
@@ -348,10 +348,15 @@ sub _pod_data {
     }
 
     # parse and insert known formats if requested
-    my $format = $target eq 'tex' ? 'latex' : $target;
+    my $format_arg = my $format = $target eq 'tex' ? 'latex' : $target;
+    if (pandoc->version ge 2) {
+        $format_arg .= '+smart';
+    }
     if ( grep { $format eq $_ } @{ $self->{parse} } ) {
         utf8::decode($content);
-        my $doc = pandoc->parse( $format => $content, '--smart' );
+        my $doc = (pandoc->version ge 2)
+            ? pandoc->parse( $format_arg => $content )
+            : pandoc->parse( $format => $content, '--smart' );
         return @{ $doc->content };
     }
 

--- a/t/pod-pandoc-modules.t
+++ b/t/pod-pandoc-modules.t
@@ -6,7 +6,7 @@ use Pod::Simple::Pandoc;
 use Pod::Pandoc::Modules;
 use Test::Exception;
 
-unless ( pandoc->bin ) {
+unless ( pandoc and pandoc->bin ) {
     plan skip_all => 'pandoc not available';
 }
 

--- a/t/pod-pandoc-modules.t
+++ b/t/pod-pandoc-modules.t
@@ -6,7 +6,7 @@ use Pod::Simple::Pandoc;
 use Pod::Pandoc::Modules;
 use Test::Exception;
 
-unless ( pandoc and pandoc->bin ) {
+unless ( eval { pandoc and pandoc->bin } ) {
     plan skip_all => 'pandoc not available';
 }
 

--- a/t/pod-pandoc-modules.t
+++ b/t/pod-pandoc-modules.t
@@ -6,7 +6,7 @@ use Pod::Simple::Pandoc;
 use Pod::Pandoc::Modules;
 use Test::Exception;
 
-if ( not ref pandoc ) {
+unless ( pandoc->bin ) {
     plan skip_all => 'pandoc not available';
 }
 

--- a/t/pod-pandoc-modules.t
+++ b/t/pod-pandoc-modules.t
@@ -6,6 +6,10 @@ use Pod::Simple::Pandoc;
 use Pod::Pandoc::Modules;
 use Test::Exception;
 
+if ( not ref pandoc ) {
+    plan skip_all => 'pandoc not available';
+}
+
 my $parser = Pod::Simple::Pandoc->new;
 
 # add

--- a/t/pod-simple-pandoc.t
+++ b/t/pod-simple-pandoc.t
@@ -5,7 +5,7 @@ use Pandoc;
 use Pod::Simple::Pandoc;
 use Test::Exception;
 
-if ( not ref pandoc ) {
+unless ( pandoc->bin ) {
     plan skip_all => 'pandoc not available';
 }
 

--- a/t/pod-simple-pandoc.t
+++ b/t/pod-simple-pandoc.t
@@ -87,7 +87,7 @@ if ( pandoc and pandoc->version >= '1.12' ) {
       ['Examples'],
       'data-sections';
 
-    is_deeply [], $doc->query( RawBlock => sub { $_->format } ), 'no RawBlack';
+    is_deeply [], $doc->query( RawBlock => sub { $_->format } ), 'no RawBlock';
 }
 
 done_testing;

--- a/t/pod-simple-pandoc.t
+++ b/t/pod-simple-pandoc.t
@@ -5,6 +5,10 @@ use Pandoc;
 use Pod::Simple::Pandoc;
 use Test::Exception;
 
+if ( not ref pandoc ) {
+    plan skip_all => 'pandoc not available';
+}
+
 my $parser = Pod::Simple::Pandoc->new();
 my $file   = 'lib/Pod/Simple/Pandoc.pm';
 

--- a/t/pod-simple-pandoc.t
+++ b/t/pod-simple-pandoc.t
@@ -5,7 +5,7 @@ use Pandoc;
 use Pod::Simple::Pandoc;
 use Test::Exception;
 
-unless ( pandoc->bin ) {
+unless ( eval { pandoc and pandoc->bin } ) {
     plan skip_all => 'pandoc not available';
 }
 


### PR DESCRIPTION
I guess the cimmit message and the diff say it all, except that this gave an install test failure in pod-simple-pandoc.t